### PR TITLE
correct typo (change fits_file to ffi_hdu)

### DIFF
--- a/tesscut_wcs_hack.ipynb
+++ b/tesscut_wcs_hack.ipynb
@@ -221,7 +221,7 @@
    ],
    "source": [
     "fits_file = \"https://archive.stsci.edu/missions/tess/ffi/s0001/2018/221/4-3/tess2018221072942-s0001-4-3-0120-s_ffic.fits\"\n",
-    "fits_file = fits.open(fits_file)\n",
+    "ffi_hdu = fits.open(fits_file)\n",
     "ffi_wcs = wcs.WCS(ffi_hdu[1].header)"
    ]
   },


### PR DESCRIPTION
In the original version, ffi_hdu is not defined, but called in the next lines. This change fixes that.